### PR TITLE
Fixed Typo

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -34,7 +34,7 @@ If you wish to hear how it sounds right away, you'll have to make sure you insta
     voice.say("Salut c'est cool")
 
 
-Ou can also, say, use scipy to get the pcm audio as a `ndarray`:
+You can also, say, use scipy to get the pcm audio as a `ndarray`:
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixed typo at https://voxpopuli.readthedocs.io/en/latest/intro.html#:~:text=Ou%20can%20also%2C%20say%2C%20use%20scipy%20to%20get%20the%20pcm%20audio%20as%20a%20ndarray%3A, changing "Ou" to "You".